### PR TITLE
Make it build on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Love2dCS was designed to be as close as possible to the original LÖVE API, as s
 * Most index begin from 1 at LÖVE. However, index will begin from 0 at Love2dCS
 * *More in development ... *
 
-Love2dCS currently based on [LÖVE 0.10.1](https://love2d.org/wiki/0.10.1)
+Love2dCS currently based on [LÖVE 0.10.2](https://love2d.org/wiki/0.10.2)
 
 Love2dCS currently supports Windows x86. The next step will be to support windows x64. Linux and OSX temporarily was not supported.
 

--- a/c_api_src/wrap_love_dll.cpp
+++ b/c_api_src/wrap_love_dll.cpp
@@ -47,6 +47,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <sstream>
+#include <typeinfo>
 
 using namespace love::timer;
 using namespace love::window;
@@ -95,7 +96,7 @@ namespace wrap
 		va_list va;
 		va_start(va, fmt);
 		ret = vprintf(fmt, va);
-		vsprintf_s(errStrBuffer, MaxBuffer, fmt, va);
+		vsnprintf(errStrBuffer, MaxBuffer, fmt, va);
 		va_end(va);
 
 		printf("\n");
@@ -1841,8 +1842,8 @@ namespace wrap
             if (touchNormalizationBug || fabs(touchinfo.x) >= 1.5 || fabs(touchinfo.y) >= 1.5 || fabs(touchinfo.dx) >= 1.5 || fabs(touchinfo.dy) >= 1.5)
             {
                 touchNormalizationBug = true;
-                windowToPixelCoords(&touchinfo.x, &touchinfo.y);
-                windowToPixelCoords(&touchinfo.dx, &touchinfo.dy);
+                if (windowInstance) windowInstance->windowToPixelCoords(&touchinfo.x, &touchinfo.y);
+                if (windowInstance) windowInstance->windowToPixelCoords(&touchinfo.dx, &touchinfo.dy);
             }
             else
 #endif

--- a/c_api_src/wrap_love_dll.h
+++ b/c_api_src/wrap_love_dll.h
@@ -151,6 +151,7 @@ namespace wrap
 	//typedef WrapSequence* pWrapSequence;
 
 #pragma region Runtime
+	int wrap_ee(const char *fmt, ...);
 	template <typename T>
 	bool4 wrap_catchexcept(const T& func)
 	{

--- a/csharp_src/Love2dBoot.cs
+++ b/csharp_src/Love2dBoot.cs
@@ -85,6 +85,8 @@ namespace Love
 
             string str = lf.GetExecutablePath();
             int index = str.LastIndexOf(@"\");
+            if (index == -1)
+                index = str.LastIndexOf(@"/");
             string path = str.Substring(0, index);
             Console.WriteLine(path);
             lf.SetSource(path);


### PR DESCRIPTION
Changes:
 - Update build instructions: requires love 0.10.2 not 0.10.1
 - Replace (non-portable) vsprintf_s with (portable) vsnprintf
 - Add wrap_ee prototype, maybe visual studio still allows implicit
     definitions?
 - Fix broken code in linux ifdef
 - Find forward slashes in the executable path if no backslashes were
    found (otherwise Substring errors because it gets a -1)

Notable issues:
 - GetExecutablePath seems to return the path to the mono binary, so the
    source directory gets set to /usr/bin
 - The hardcoded library name means the linux c library needs to be
     called "liblove.dll" or "liblove.dll.so".